### PR TITLE
Feat/hero section

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
-import { Fragment } from "react";
 import GooeyNavbar from "@/components/GooeyNavbar";
 import { fetchStarCount } from "@/lib/github";
 import HeroCta from "@/components/HeroCta";
+import HeroIntro from "@/components/HeroIntro";
 import ComponentsShowcase from "@/components/ComponentsShowcase";
 import Footer from "@/components/Footer";
 
@@ -19,51 +19,26 @@ export default async function Home() {
     <>
       <section className="relative w-full p-1.5 md:p-2.5">
         <div
-          className="relative flex min-h-[calc(100svh-0.75rem)] w-full items-center justify-center overflow-hidden rounded-[45px] md:min-h-[calc(100svh-1.25rem)]"
+          className="relative flex min-h-[calc(100svh-0.75rem)] w-full items-center justify-center overflow-hidden rounded-[45px] border border-black/[0.04] bg-[#F5F5F7] dark:border-transparent dark:border-apple dark:bg-[#121212] md:min-h-[calc(100svh-1.25rem)]"
           style={{ cornerShape: "squircle" } as React.CSSProperties}
         >
+          <GooeyNavbar stars={stars} />
+
           <img
-            src="/assets/landing/herobg.webp"
+            src="/logos/Rareui.svg"
             alt=""
             aria-hidden="true"
-            className="pointer-events-none absolute inset-0 size-full rounded-[inherit] object-cover"
+            className="pointer-events-none absolute left-1/2 top-[68%] w-[min(88vw,860px)] max-w-none -translate-x-1/2 -translate-y-1/2 opacity-[0.05] [filter:brightness(0)] dark:opacity-[0.07] dark:[filter:brightness(0)_invert(1)]"
           />
-          <div className="pointer-events-none absolute inset-0 rounded-[inherit] bg-linear-to-t from-background from-6% to-transparent" />
-          <div className="relative mx-auto flex w-full max-w-6xl flex-col items-center justify-center gap-3 px-4 pb-32 pt-24 text-center sm:gap-4 sm:px-6">
-            <div>
-              <GooeyNavbar stars={stars} />
-            </div>
-            <div className="flex items-center gap-2 rounded-full bg-white/35 py-1.5 pl-4 pr-3.5 backdrop-blur-xl dark:bg-neutral-950/30">
-              <span className="font-runde text-sm font-medium text-black dark:text-white">
-                Backed by
-              </span>
-              {BACKERS.map((backer, index) => (
-                <Fragment key={backer.name}>
-                  {index > 0 && (
-                    <span
-                      aria-hidden="true"
-                      className="h-3.5 w-px bg-black/20 dark:bg-white/20"
-                    />
-                  )}
-                  <a
-                    href={backer.href}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={backer.pillNudge}
-                  >
-                    <BackerLogo backer={backer} className={backer.pillHeight} />
-                  </a>
-                </Fragment>
-              ))}
-            </div>
-            <h1 className="max-w-4xl text-balance dark:text-white font-runde text-black text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl">
-              Tasteful Components, Made to Stand Out.
-            </h1>
-            <p className="max-w-xl font-medium text-black/80 dark:text-white/80 sm:text-lg">
-              A collection of rare, animated components. Browse them in action
-              below and install any component with shadcn CLI.
-            </p>
-            <HeroCta />
+          <div className="pointer-events-none absolute inset-0 hidden rounded-[inherit] bg-[radial-gradient(120%_75%_at_50%_-5%,rgba(255,255,255,0.07),transparent_60%)] dark:block" />
+
+          <div className="relative mx-auto flex w-full max-w-6xl flex-col items-center justify-center gap-3 px-4 pt-20 text-center sm:gap-4 sm:px-6">
+            <HeroIntro
+              headline="Tasteful Components, Made to Stand Out."
+              sub="A collection of rare, animated components. Browse them in action below and install any component with shadcn CLI."
+            >
+              <HeroCta />
+            </HeroIntro>
           </div>
         </div>
       </section>
@@ -84,19 +59,16 @@ type Backer = {
   href: string;
   lightSrc: string;
   darkSrc: string;
-  pillHeight: string;
   cardHeight: string;
-  pillNudge?: string;
 };
 
-// mintlify's wordmark has a far larger x-height and sits higher in its artboard, so it needs its own size and baseline nudge
+// mintlify's wordmark has a far larger x-height and sits higher in its artboard, so it needs its own size
 const BACKERS: Backer[] = [
   {
     name: "Databuddy",
     href: "https://www.databuddy.cc",
     lightSrc: "/logos/databuddydark.svg",
     darkSrc: "/logos/databuddywhite.svg",
-    pillHeight: "h-4.5",
     cardHeight: "h-10 sm:h-12",
   },
   {
@@ -104,9 +76,7 @@ const BACKERS: Backer[] = [
     href: "https://mintlify.com",
     lightSrc: "/logos/mintlifydark.png",
     darkSrc: "/logos/mintlifylight.png",
-    pillHeight: "h-3.5",
     cardHeight: "h-8 sm:h-9.5",
-    pillNudge: "translate-y-[2px]",
   },
 ];
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ export default async function Home() {
           />
           <div className="pointer-events-none absolute inset-0 hidden rounded-[inherit] bg-[radial-gradient(120%_75%_at_50%_-5%,rgba(255,255,255,0.07),transparent_60%)] dark:block" />
 
-          <div className="relative mx-auto flex w-full max-w-6xl flex-col items-center justify-center gap-3 px-4 pt-20 text-center sm:gap-4 sm:px-6">
+          <div className="relative mx-auto flex w-full max-w-6xl flex-col items-center justify-center gap-3 px-4 pb-20 pt-28 text-center sm:gap-4 sm:px-6">
             <HeroIntro
               headline="Tasteful Components, Made to Stand Out."
               sub="A collection of rare, animated components. Browse them in action below and install any component with shadcn CLI."
@@ -44,14 +44,11 @@ export default async function Home() {
       </section>
       <ComponentsShowcase />
       <BackersSection />
-      {/* <DemoSection /> */}
       <Footer />
     </>
   );
 }
 
-const X_URL = "https://x.com/swamimalode";
-const GITHUB_URL = "https://github.com/swamimalode07/rare-ui";
 const SPONSOR_URL = "https://github.com/sponsors/swamimalode07";
 
 type Backer = {
@@ -166,68 +163,6 @@ function BackersSection() {
           </a>
         ))}
         <SponsorSlot />
-      </div>
-    </section>
-  );
-}
-
-function DemoSection() {
-  return (
-    <section className="mx-auto flex min-h-screen w-full max-w-6xl flex-col items-center justify-center gap-4 px-6 py-24 text-center">
-      <span className="flex items-center gap-2 rounded-full border border-border px-3.5 py-1.5 text-xs font-medium text-muted-foreground">
-        <span className="relative flex h-2 w-2">
-          <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-[#FC4C01] opacity-60" />
-          <span className="relative inline-flex h-2 w-2 rounded-full bg-[#FC4C01]" />
-        </span>
-        Work in progress
-      </span>
-      <h2 className="max-w-2xl text-balance font-runde text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl">
-        Rare UI is being built in the open.
-      </h2>
-      <p className="max-w-xl text-balance font-medium text-muted-foreground sm:text-lg">
-        The landing page you&apos;re on is still taking shape, and new
-        components land regularly. Follow the journey on X and star the
-        project on GitHub to keep up.
-      </p>
-      <div className="mt-2 flex flex-wrap items-center justify-center gap-3">
-        <a
-          href={X_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="flex h-12 items-center gap-2.5 rounded-full bg-neutral-900 px-6 text-sm font-semibold text-white transition-colors duration-150 ease-out hover:bg-neutral-800"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            aria-hidden="true"
-          >
-            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231 5.451-6.231Zm-1.161 17.52h1.833L7.084 4.126H5.117l11.966 15.644Z" />
-          </svg>
-          Follow the journey
-        </a>
-        <a
-          href={GITHUB_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="flex h-12 items-center gap-2.5 rounded-full border border-border bg-card px-6 text-sm font-semibold transition-colors duration-150 ease-out hover:bg-muted"
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="#FC4C01"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            xmlns="http://www.w3.org/2000/svg"
-            className="h-4 w-4"
-            aria-hidden="true"
-          >
-            <path d="M11.525 2.295a.53.53 0 0 1 .95 0l2.31 4.679a2.123 2.123 0 0 0 1.595 1.16l5.166.756a.53.53 0 0 1 .294.904l-3.736 3.638a2.123 2.123 0 0 0-.611 1.878l.882 5.14a.53.53 0 0 1-.771.56l-4.618-2.428a2.122 2.122 0 0 0-1.973 0L6.396 21.01a.53.53 0 0 1-.77-.56l.881-5.139a2.122 2.122 0 0 0-.611-1.879L2.16 9.795a.53.53 0 0 1 .294-.906l5.165-.755a2.122 2.122 0 0 0 1.597-1.16z" />
-          </svg>
-          Star on GitHub
-        </a>
       </div>
     </section>
   );

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -45,7 +45,7 @@ export default function Footer() {
       <FluidWave />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-linear-to-b from-black to-transparent" />
 
-      <div className="relative flex min-h-[85svh] flex-col px-6 sm:px-10">
+      <div className="relative mx-auto flex min-h-[85svh] w-full max-w-[96rem] flex-col px-6 pt-24 sm:px-10">
         <div className="h-px w-full bg-white/10" />
 
         <div className="flex flex-wrap items-center justify-between gap-6 py-8">

--- a/components/HeroIntro.tsx
+++ b/components/HeroIntro.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Fragment } from "react";
+import { motion, useReducedMotion } from "motion/react";
+
+const spring = { type: "spring", stiffness: 300, damping: 22 } as const;
+
+const WORD_STEP = 0.045;
+
+// no opacity in here on purpose: motion serializes the hidden state into the ssr markup, so fading from
+// zero would leave the headline and the cta invisible if the bundle never runs
+const rise = {
+  hidden: { y: 18, filter: "blur(10px)" },
+  shown: { y: 0, filter: "blur(0px)" },
+};
+
+export default function HeroIntro({
+  headline,
+  sub,
+  children,
+}: {
+  headline: string;
+  sub: string;
+  children: React.ReactNode;
+}) {
+  const reduceMotion = useReducedMotion();
+  const words = headline.split(" ");
+
+  const step = (index: number) =>
+    reduceMotion ? { duration: 0 } : { ...spring, delay: index * WORD_STEP };
+
+  return (
+    <>
+      <h1 className="max-w-4xl text-balance font-runde text-4xl font-bold tracking-tight text-black dark:text-white sm:text-5xl md:text-6xl lg:text-7xl">
+        {words.map((word, index) => (
+          <Fragment key={`${word}-${index}`}>
+            <motion.span
+              initial={reduceMotion ? false : rise.hidden}
+              animate={rise.shown}
+              transition={step(index)}
+              className="inline-block"
+            >
+              {word}
+            </motion.span>
+            {index < words.length - 1 && " "}
+          </Fragment>
+        ))}
+      </h1>
+
+      <motion.p
+        initial={reduceMotion ? false : rise.hidden}
+        animate={rise.shown}
+        transition={step(words.length + 1)}
+        className="max-w-xl font-medium text-black/60 dark:text-white/60 sm:text-lg"
+      >
+        {sub}
+      </motion.p>
+
+      <motion.div
+        initial={reduceMotion ? false : rise.hidden}
+        animate={rise.shown}
+        transition={step(words.length + 3)}
+      >
+        {children}
+      </motion.div>
+    </>
+  );
+}

--- a/components/HeroIntro.tsx
+++ b/components/HeroIntro.tsx
@@ -7,8 +7,6 @@ const spring = { type: "spring", stiffness: 300, damping: 22 } as const;
 
 const WORD_STEP = 0.045;
 
-// no opacity in here on purpose: motion serializes the hidden state into the ssr markup, so fading from
-// zero would leave the headline and the cta invisible if the bundle never runs
 const rise = {
   hidden: { y: 18, filter: "blur(10px)" },
   shown: { y: 0, filter: "blur(0px)" },


### PR DESCRIPTION
## New hero, footer width cap, light mode footer

- New hero: flat surface card instead of the photo background, logo watermark, navbar floats over it. Headline/sub/CTA moved into `HeroIntro` with a per-word spring rise.
- Dropped the "Backed by" pill from the hero.
- Footer content capped at `max-w-[96rem]` so it stops spreading on ultrawide screens.
- Added `pt-24` to the footer so the gap above it matches the other sections.
- Footer works in light mode. It was hardcoded black/white, and `FluidWave` painted an opaque black rectangle; the shader now outputs alpha over a transparent context. Dark mode is unchanged.
- Removed the unused `DemoSection` and the constants it orphaned.