### PR TITLE
 fix: mobile overflow on hero install command

### DIFF
--- a/components/CopyButton.tsx
+++ b/components/CopyButton.tsx
@@ -78,7 +78,7 @@ export default function CopyButton({
         className,
       )}
     >
-      <span className={cn("grid place-items-center", iconClassName)}>
+      <span className={cn("grid shrink-0 place-items-center", iconClassName)}>
         <motion.span
           className={layer}
           initial={false}

--- a/components/HeroCta.tsx
+++ b/components/HeroCta.tsx
@@ -53,14 +53,14 @@ export default function HeroCta() {
   const shift = (px: number) => (reduceMotion ? 0 : px);
 
   return (
-    <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+    <div className="mt-4 flex flex-col items-center justify-center gap-3 sm:flex-row sm:flex-wrap">
       <motion.div
         initial={false}
         animate={{ x: hovered === "cta" ? shift(-SIDE_SHIFT) : 0 }}
         transition={spring}
         onHoverStart={() => setHovered("pill")}
         onHoverEnd={() => setHovered((h) => (h === "pill" ? null : h))}
-        className="relative max-w-full"
+        className="relative min-w-0 max-w-[75vw] sm:max-w-full"
       >
         <StretchSquircleBg
           hovered={hovered === "pill"}
@@ -69,9 +69,9 @@ export default function HeroCta() {
         <CopyButton
           value={INSTALL_COMMAND}
           label="Copy command"
-          className="relative h-12 max-w-full flex-row-reverse gap-2 pl-4 pr-4 text-white/50 hover:text-white sm:pl-5"
+          className="relative h-12 w-full max-w-full flex-row-reverse gap-2 pl-4 pr-4 text-white/50 hover:text-white sm:w-auto sm:pl-5"
         >
-          <code className="overflow-x-auto whitespace-nowrap font-mono text-xs font-semibold text-white sm:text-sm">
+          <code className="min-w-0 flex-1 truncate font-mono text-xs font-semibold text-white sm:flex-none sm:text-sm">
             npx shadcn@latest add {REGISTRY_REPO}
             <span className="font-normal text-white/50">/fluid-orb</span>
           </code>
@@ -84,7 +84,7 @@ export default function HeroCta() {
         transition={spring}
         onHoverStart={() => setHovered("cta")}
         onHoverEnd={() => setHovered((h) => (h === "cta" ? null : h))}
-        className="group relative"
+        className="group relative shrink-0"
       >
         <StretchSquircleBg
           hovered={hovered === "cta"}


### PR DESCRIPTION
Fixes the hero install command overflowing full-width on mobile and the copy icon getting squeezed out. Now truncates with an ellipsis and stacks above the Quick Start button.

**Before**
<img width="179" height="376" alt="image" src="https://github.com/user-attachments/assets/0d2066f7-8a2d-4e6b-8ebf-2d74a62f174f" />


**After**
<img width="171" height="370" alt="image" src="https://github.com/user-attachments/assets/26313548-cd8a-47f2-9018-9b087198caec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for hero call-to-action controls across screen sizes.
  * Copy and CTA buttons now maintain their sizing and alignment more reliably.
  * Long command text truncates cleanly instead of causing horizontal scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->