### PR TITLE
fix: Change Bun install command text color to enhance visibility during light mode

### DIFF
--- a/components/Description/InstallCommand.tsx
+++ b/components/Description/InstallCommand.tsx
@@ -16,7 +16,7 @@ const ACTIVE_COLOR: Record<PackageManager, string> = {
   npm: "#CB3837", 
   pnpm: "#F9AD00", 
   yarn: "#38BDF8",
-  bun: "#FFFFFF",
+  bun: "#FF9557",
 };
 
 export default function InstallCommand({ item }: { item: ComponentItem }) {


### PR DESCRIPTION
**Summary**
Fixes the visibility issue of "bun" installation command in every component description, by changing the text and icon color of bun command to #FF9557 (A little orangish) , instead of #FFFFFF (plain white). This ensures the button text and icon will be clearly visible in both dark and light mode

**Photos**
<img width="537" height="167" alt="image" src="https://github.com/user-attachments/assets/c0d509e3-3d37-4205-9a7d-93626b7f3213" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Bun package-manager active color to a warmer orange shade for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->