### PR TITLE
added contrast text color for the footer text

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -206,7 +206,6 @@ html {
   color: #fc4c01;
 }
 
-/* plain css, not @utility: the rule above is unlayered and would beat any layered utility */
 .selection-contrast::selection,
 .selection-contrast *::selection {
   color: #000;

--- a/app/globals.css
+++ b/app/globals.css
@@ -206,6 +206,17 @@ html {
   color: #fc4c01;
 }
 
+/* plain css, not @utility: the rule above is unlayered and would beat any layered utility */
+.selection-contrast::selection,
+.selection-contrast *::selection {
+  color: #000;
+}
+
+.dark .selection-contrast::selection,
+.dark .selection-contrast *::selection {
+  color: #fff;
+}
+
 [vaul-drawer] {
   transition: transform 0.2s cubic-bezier(0.165, 0.84, 0.44, 1);
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -67,7 +67,7 @@ export default function Footer() {
         </div>
 
         <div className="flex flex-1 items-center py-16">
-          <h2 className="font-runde text-[clamp(3rem,12.5vw,10.5rem)] font-bold leading-[0.92] tracking-tight">
+          <h2 className="selection-contrast font-runde text-[clamp(3rem,12.5vw,10.5rem)] font-bold leading-[0.92] tracking-tight">
             Tasteful Components
           </h2>
         </div>


### PR DESCRIPTION
Before
<img width="1469" height="881" alt="Screenshot 2026-08-09 at 1 22 06 AM" src="https://github.com/user-attachments/assets/15895cd0-f13c-460c-a8b4-62ecc565989c" />
After 
<img width="1470" height="835" alt="Screenshot 2026-08-09 at 1 22 51 AM" src="https://github.com/user-attachments/assets/6b933067-4be7-4609-94ab-a7fc0ec6b5b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved text selection contrast for the footer heading.
  * Selected text now appears black by default and white in dark mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->